### PR TITLE
ページネーション機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'rails-i18n'
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem "rack-cors"
+gem 'rack-cors'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/app/controllers/api/v1/user/lessons_controller.rb
+++ b/app/controllers/api/v1/user/lessons_controller.rb
@@ -1,8 +1,13 @@
 class Api::V1::User::LessonsController < ApplicationController
   def index
-    form = Api::V1::User::Lessons::IndexForm.new
-    response = form.index
-    render json: response
+    form = Api::V1::User::Lessons::IndexForm.new(params)
+
+    if form.valid?
+      response = form.index
+      render json: response
+    else
+      render json: ErrorResponse.base_response(I18n.t('errors.bad_request'), STATUS_BAD_REQUEST)
+    end
   end
 
   def show

--- a/app/forms/api/v1/user/lessons/index_form.rb
+++ b/app/forms/api/v1/user/lessons/index_form.rb
@@ -1,6 +1,24 @@
 class Api::V1::User::Lessons::IndexForm
+  include ActiveModel::Model
+
+  attr_reader :page
+
+  validates :page, presence: true
+
+  def initialize(params)
+    @page = params[:page]
+  end
+
   def index
-    lessons = Lesson.all
+    lessons = Lesson.all.page(valid_params[:page]).per(10)
     ApiResponse.base_response(Api::V1::User::LessonsResponse.index_success(lessons), nil, STATUS_SUCCESS)
+  end
+
+  private
+
+  def valid_params
+    {
+      page:
+    }
   end
 end

--- a/app/forms/api/v1/user/lessons/index_form.rb
+++ b/app/forms/api/v1/user/lessons/index_form.rb
@@ -10,7 +10,7 @@ class Api::V1::User::Lessons::IndexForm
   end
 
   def index
-    lessons = Lesson.all.page(valid_params[:page]).per(10)
+    lessons = Lesson.all.page(valid_params[:page])
     ApiResponse.base_response(Api::V1::User::LessonsResponse.index_success(lessons), nil, STATUS_SUCCESS)
   end
 

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,4 +1,6 @@
 class Lesson < ApplicationRecord
+  paginates_per 3
+
   validates :title, :price, :category, :time, presence: true
 
   enum category: { muscle: 1, aerobic_exercise: 2, yoga: 3, pilates: 4, stretch: 5, meal_management: 6, counseling: 7 }

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,5 +1,5 @@
 class Lesson < ApplicationRecord
-  paginates_per 3
+  paginates_per 10
 
   validates :title, :price, :category, :time, presence: true
 

--- a/app/responses/api/v1/user/lessons_response.rb
+++ b/app/responses/api/v1/user/lessons_response.rb
@@ -2,7 +2,8 @@ class Api::V1::User::LessonsResponse
   class << self
     def index_success(lessons)
       {
-        lessons: lessons.map { |lesson| build_lesson(lesson) }
+        lessons: lessons.map { |lesson| build_lesson(lesson) },
+        is_last_page: lessons.current_page == lessons.total_pages
       }
     end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - 3000:3000
     depends_on:
       - db
+    tty: true
+    stdin_open: true
 
 volumes:
   mysql_data:

--- a/spec/forms/api/v1/user/lessons/index_form_spec.rb
+++ b/spec/forms/api/v1/user/lessons/index_form_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'Api::V1::User::Lessons::IndexForm' do
     let(:index_form) { Api::V1::User::Lessons::IndexForm.new(params) }
 
     context 'pageがある場合' do
-      let!(:lessons) { create_list(:lesson, 2) }
+      let!(:lessons) { create_list(:lesson, 12) }
       let(:params) { { page: 1 } }
 
-      it '正しいレスポンスが返ってくること' do
+      it '1ページ目に最初の10件が表示されること' do
         expect(index_form.index).to eq ApiResponse.base_response(
-          Api::V1::User::LessonsResponse.index_success(lessons), nil, STATUS_SUCCESS
+          Api::V1::User::LessonsResponse.index_success(lessons.first(10)), nil, STATUS_SUCCESS
         )
       end
     end

--- a/spec/forms/api/v1/user/lessons/index_form_spec.rb
+++ b/spec/forms/api/v1/user/lessons/index_form_spec.rb
@@ -2,15 +2,25 @@ require 'rails_helper'
 
 RSpec.describe 'Api::V1::User::Lessons::IndexForm' do
   describe '#index' do
-    let(:index_form) { Api::V1::User::Lessons::IndexForm.new }
+    let(:index_form) { Api::V1::User::Lessons::IndexForm.new(params) }
 
-    context 'lessonが存在する場合' do
+    context 'pageがある場合' do
       let!(:lessons) { create_list(:lesson, 2) }
+      let(:params) { { page: 1 } }
 
       it '正しいレスポンスが返ってくること' do
         expect(index_form.index).to eq ApiResponse.base_response(
           Api::V1::User::LessonsResponse.index_success(lessons), nil, STATUS_SUCCESS
         )
+      end
+    end
+
+    context 'pageがない場合' do
+      let(:params) { { page: nil } }
+
+      it 'エラーを返すこと' do
+        index_form.valid?
+        expect(index_form.errors[:page]).to be_present
       end
     end
   end

--- a/spec/requests/api/v1/user/lessons_spec.rb
+++ b/spec/requests/api/v1/user/lessons_spec.rb
@@ -1,48 +1,50 @@
 require 'rails_helper'
 
-describe 'GET /api/v1/user/lessons' do
-  context '正常系' do
+describe 'LessonAPI' do
+  describe 'GET /api/v1/user/lessons' do
+    context '正常系' do
+      let(:lesson) { create(:lesson) }
+      let(:params) { { page: 1 } }
+
+      before do
+        lesson
+        get api_v1_user_lessons_path, params:
+      end
+
+      it { expect(response).to have_http_status :ok }
+      it { expect(JSON.parse(response.body)['data']['lessons'][0]['id']).to eq lesson.id }
+      it { expect(JSON.parse(response.body)['data']['lessons'][0]['title']).to eq lesson.title }
+      it { expect(JSON.parse(response.body)['data']['lessons'][0]['category']).to eq lesson.category }
+      it { expect(JSON.parse(response.body)['data']['lessons'][0]['price']).to eq lesson.price }
+      it { expect(JSON.parse(response.body)['data']['lessons'][0]['time']).to eq lesson.time }
+    end
+  end
+
+  describe 'GET /api/v1/user/lessons/:id' do
     let(:lesson) { create(:lesson) }
-    let(:params) { { page: 1 } }
 
-    before do
-      lesson
-      get api_v1_user_lessons_path, params:
+    context '正常系' do
+      before do
+        get api_v1_user_lesson_path(lesson.id)
+      end
+
+      it { expect(response).to have_http_status :ok }
+      it { expect(JSON.parse(response.body)['data']['lesson']['id']).to eq lesson.id }
+      it { expect(JSON.parse(response.body)['data']['lesson']['title']).to eq lesson.title }
+      it { expect(JSON.parse(response.body)['data']['lesson']['category']).to eq lesson.category }
+      it { expect(JSON.parse(response.body)['data']['lesson']['price']).to eq lesson.price }
+      it { expect(JSON.parse(response.body)['data']['lesson']['time']).to eq lesson.time }
     end
 
-    it { expect(response).to have_http_status :ok }
-    it { expect(JSON.parse(response.body)['data']['lessons'][0]['id']).to eq lesson.id }
-    it { expect(JSON.parse(response.body)['data']['lessons'][0]['title']).to eq lesson.title }
-    it { expect(JSON.parse(response.body)['data']['lessons'][0]['category']).to eq lesson.category }
-    it { expect(JSON.parse(response.body)['data']['lessons'][0]['price']).to eq lesson.price }
-    it { expect(JSON.parse(response.body)['data']['lessons'][0]['time']).to eq lesson.time }
-  end
-end
+    context '異常系' do
+      let(:not_exist_lesson_id) { lesson.id + 1 }
 
-describe 'GET /api/v1/user/lessons/:id' do
-  let(:lesson) { create(:lesson) }
+      before do
+        get api_v1_user_lesson_path(not_exist_lesson_id)
+      end
 
-  context '正常系' do
-    before do
-      get api_v1_user_lesson_path(lesson.id)
+      it { expect(JSON.parse(response.body)['error']).to eq 'レッスンが見つかりません' }
+      it { expect(JSON.parse(response.body)['status']).to eq 404 }
     end
-
-    it { expect(response).to have_http_status :ok }
-    it { expect(JSON.parse(response.body)['data']['lesson']['id']).to eq lesson.id }
-    it { expect(JSON.parse(response.body)['data']['lesson']['title']).to eq lesson.title }
-    it { expect(JSON.parse(response.body)['data']['lesson']['category']).to eq lesson.category }
-    it { expect(JSON.parse(response.body)['data']['lesson']['price']).to eq lesson.price }
-    it { expect(JSON.parse(response.body)['data']['lesson']['time']).to eq lesson.time }
-  end
-
-  context '異常系' do
-    let(:not_exist_lesson_id) { lesson.id + 1 }
-
-    before do
-      get api_v1_user_lesson_path(not_exist_lesson_id)
-    end
-
-    it { expect(JSON.parse(response.body)['error']).to eq 'レッスンが見つかりません' }
-    it { expect(JSON.parse(response.body)['status']).to eq 404 }
   end
 end

--- a/spec/requests/api/v1/user/lessons_spec.rb
+++ b/spec/requests/api/v1/user/lessons_spec.rb
@@ -3,10 +3,11 @@ require 'rails_helper'
 describe 'GET /api/v1/user/lessons' do
   context '正常系' do
     let(:lesson) { create(:lesson) }
+    let(:params) { { page: 1 } }
 
     before do
       lesson
-      get api_v1_user_lessons_path
+      get api_v1_user_lessons_path, params:
     end
 
     it { expect(response).to have_http_status :ok }


### PR DESCRIPTION
## 1. 実装内容

- レッスン一覧にページネーション機能を追加
- 1ページあたり10件表示されるようにした
--------------------------------------
## 2. スクリーンショット（必要に応じて）

<img src="" width="">

--------------------------------------
## 3. Checklist

- [x] 動作確認したこと
- [ ] 追加/更新した箇所のテストを追加/修正したこと
- [x] ローカルでRubocopが通っていること
- [x] ローカルでRspecが通っていること

--------------------------------------
## 4. 保留にしたTODO（あれば）
- Rubocopでspec/requests/.../lessons_spec.rbの`describe 'GET /api/v1/user/lessons'`に`Do not use multiple top-level example groups - try to nest them.`という警告があったがどう修正していいかわからず、とりあえず保留。

--------------------------------------
## 5. その他（参考にした記事などあれば）