### PR TITLE
レッスン一覧のソート機能

### DIFF
--- a/app/forms/api/v1/user/lessons/index_form.rb
+++ b/app/forms/api/v1/user/lessons/index_form.rb
@@ -1,7 +1,7 @@
 class Api::V1::User::Lessons::IndexForm
   include ActiveModel::Model
 
-  attr_reader :page, :categories, :genders, :min_price, :max_price
+  attr_reader :page, :categories, :genders, :min_price, :max_price, :order
 
   validates :page, presence: true
 
@@ -11,6 +11,7 @@ class Api::V1::User::Lessons::IndexForm
     @genders = params[:genders]
     @min_price = params[:min_price]
     @max_price = params[:max_price]
+    @order = params[:order]
   end
 
   def index
@@ -20,7 +21,15 @@ class Api::V1::User::Lessons::IndexForm
               else
                 Lesson.eager_load(:trainer)
               end
-    paginated_lessons = lessons.page(valid_params[:page])
+    sorts = case valid_params[:order]
+            when 'low_price'
+              lessons.order('price ASC')
+            when 'high_price'
+              lessons.order('price DESC')
+            when 'created_at_desc'
+              lessons.order('lessons.created_at DESC')
+            end
+    paginated_lessons = sorts.page(valid_params[:page])
     ApiResponse.base_response(Api::V1::User::LessonsResponse.index_success(paginated_lessons), nil, STATUS_SUCCESS)
   end
 
@@ -28,6 +37,7 @@ class Api::V1::User::Lessons::IndexForm
 
   def valid_params
     {
+      order:,
       page:,
       query: {
         categories:,

--- a/spec/forms/api/v1/user/lessons/index_form_spec.rb
+++ b/spec/forms/api/v1/user/lessons/index_form_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe 'Api::V1::User::Lessons::IndexForm' do
     let(:index_form) { Api::V1::User::Lessons::IndexForm.new(params) }
 
     context 'pageがある場合' do
-      let(:lessons) { create_list(:lesson, 11, category: :muscle) }
-      let(:params) { { page: 1 } }
+      let(:lessons) { create_list(:lesson, 11, category: :muscle, created_at: '2022.12.12 12:12:12') }
+      let(:params) { { page: 1, order: 'created_at_desc' } }
 
       before do
-        create(:lesson, category: :yoga)
+        create(:lesson, category: :yoga, created_at: '2022.12.13 12:12:12')
         lessons
       end
 
@@ -18,7 +18,7 @@ RSpec.describe 'Api::V1::User::Lessons::IndexForm' do
       end
 
       context 'queryがある場合' do
-        let(:params) { { categories: ['muscle'], page: 1 } }
+        let(:params) { { categories: ['muscle'], page: 1, order: 'created_at_desc' } }
 
         it '該当するカテゴリーのレッスンのみが返されること' do
           expect(index_form.index[:data][:lessons].to_a.pluck(:category)).to eq Array.new(10, 'muscle')
@@ -26,7 +26,7 @@ RSpec.describe 'Api::V1::User::Lessons::IndexForm' do
       end
 
       context 'queryがない場合' do
-        it '任意のカテゴリーのレッスンが返されること' do
+        it '新着順に任意のカテゴリーのレッスンが返されること' do
           expect(
             index_form.index[:data][:lessons].to_a.pluck(:category)
           ).to eq Array.new(9, 'muscle').unshift('yoga')

--- a/spec/requests/api/v1/user/lessons_spec.rb
+++ b/spec/requests/api/v1/user/lessons_spec.rb
@@ -4,7 +4,7 @@ describe 'LessonAPI' do
   describe 'GET /api/v1/user/lessons' do
     context '正常系' do
       let(:lesson) { create(:lesson) }
-      let(:params) { { page: 1 } }
+      let(:params) { { page: 1, order: 'low_price' } }
 
       before do
         lesson


### PR DESCRIPTION
## 1. 実装内容
- レッスン一覧のソート機能
　- paramsにorder追加
　- 条件分岐で`'low_price'` `'high_price'` `'created_at_desc'` それぞれの並び替え処理

--------------------------------------
## 2. スクリーンショット（必要に応じて）

<img src="" width="">

--------------------------------------
## 3. Checklist

- [x] 動作確認したこと
- [x] 追加/更新した箇所のテストを追加/修正したこと
- [x] ローカルでRubocopが通っていること
- [x] ローカルでRspecが通っていること

--------------------------------------
## 4. 保留にしたTODO（あれば）


--------------------------------------
## 5. その他（参考にした記事などあれば）